### PR TITLE
Updated the documentation in the Installation & Setup and Certificates & Domains sections under Cloud Deployment.

### DIFF
--- a/docs/deployment/cloud/certificates-domains.md
+++ b/docs/deployment/cloud/certificates-domains.md
@@ -3,7 +3,16 @@ slug: /deployment/cloud/certificates-domains
 title: Certificates & Domains
 ---
 
-Manually replace these files in the `certs/` directory with your valid certs:
+Clone the `mango_cloud_cert_generation` repo to create and update valid certs:
+
+```bash
+git clone https://github.com/routerarchitects/mango_cloud_cert_generation.git
+cd mango_cloud_cert_generation
+```
+
+Follow the [README.md](https://github.com/routerarchitects/mango_cloud_cert_generation/blob/main/README.md) to generate device certificates and MangoCloud server certificates.
+
+Then confirm the `certs/` directory is updated with your valid certs:
 
 - `clientcas.pem`
 - `issuer.pem`
@@ -44,6 +53,12 @@ sudo certbot certonly --standalone \
 ```
 
 Certs will be created in `/etc/letsencrypt/live/<DOMAIN_NAME>/`.
+
+Verify with:
+
+```bash
+sudo ls -l /etc/letsencrypt/live/
+```
 
 Copy them into the OpenWiFi certs directory:
 
@@ -117,7 +132,7 @@ chmod +x update_openwifi_public_certs.sh
 ./update_openwifi_public_certs.sh
 ```
 
-Update the `owgw-ui` and `owprov-ui` sections to use public REST certs:
+Update `docker-compose.yml` with `owgw-ui` and `owprov-ui` section certs paths to public certs:
 
 ```diff
 -      - "./certs/restapi-cert.pem:/etc/nginx/restapi-cert.pem"

--- a/docs/deployment/cloud/installation-setup.md
+++ b/docs/deployment/cloud/installation-setup.md
@@ -21,9 +21,8 @@ Create working directory and clone the deployment repo:
 ```bash
 mkdir openwifi-sdk
 cd openwifi-sdk
-git clone https://github.com/Telecominfraproject/wlan-cloud-ucentral-deploy.git
-cd wlan-cloud-ucentral-deploy/docker-compose
-git checkout release/v3.2.0
+git clone https://github.com/routerarchitects/ra_wlan-cloud-ucentral-deploy.git
+cd ra_wlan-cloud-ucentral-deploy/docker-compose
 ```
 
 Note: Remove port 80 from `docker-compose.yml`, as it is required by Certbot during certificate renewal.
@@ -43,6 +42,8 @@ FIRMWAREDB_MAXAGE=3650
 
 ### Update `docker-compose.yml` images and matching `.env` files
 
+In `docker-compose.yml`, replace `image: "docker.io/bitnami/kafka:${KAFKA_TAG}"` with `image: "docker.io/bitnamilegacy/kafka:${KAFKA_TAG}"` in both the `kafka` and `init-kafka` services.
+
 If you are using custom-built images (or different tags), replace the image names/tags in `docker-compose.yml`, then review each service's referenced `.env` file to ensure required variables and paths match your deployment.
 
 ## Docker & Docker Compose
@@ -55,7 +56,3 @@ sudo usermod -aG docker $USER
 newgrp docker
 sudo chown -R $USER:$USER .
 ```
-
-## Repo checkout & versions
-
-Ensure all component versions align with the `release/v3.2.0` deployment branch.


### PR DESCRIPTION
***Issue***
#10 

**Feature description:-**
This feature adds visibility to the MangoCloud operations documentation on the Docs page.

**Test Steps:**
1. Navigate to https://www.mangowifi.cloud/.
2. Click on the Docs page.
3. Verify details for Cloud Deployment sections.

**Expected Behavior:**
The MangoCloud operations documentation should be displayed on the Docs page.