### PR TITLE
update mangocloud roadmap

### DIFF
--- a/src/pages/roadmap.mdx
+++ b/src/pages/roadmap.mdx
@@ -7,7 +7,7 @@ description: Transparent view into MangoCloud deliverables and release milestone
 
 MangoCloud tracks deliverables publicly to keep the OpenLAN ecosystem aligned on priorities. Releases follow semantic versioning with LTS indicators when features reach production-readiness for ISPs.
 
-## v1.0 – Residential WiFi (In Progress)
+## v1.0 – Residential WiFi (Released)
 
 > **Scope:** Enable full residential WiFi support with subscriber self-service, improved UI/UX, and backend scalability.
 
@@ -19,7 +19,7 @@ MangoCloud tracks deliverables publicly to keep the OpenLAN ecosystem aligned on
 - Introduction of a new topology service written in Go for real-time topology visibility
 - Scalability support for up to 50,000 simultaneous connections
 
-## v2.0 – MDU & Large-Scale Deployment (Planned)
+## v2.0 – MDU & Large-Scale Deployment (In Progress)
 
 > **Scope:** Extend Mango WiFi Cloud to support MDUs, large-scale ISP deployments, and advanced service integrations.
 


### PR DESCRIPTION
**Description**
This PR updates the MangoCloud roadmap to reflect the latest release progress.

**Changes:**

- Marked v1.0 – Residential WiFi as Released
- Updated v2.0 – MDU & Large-Scale Deployment status to In Progress